### PR TITLE
[CMD] Add creategenesis.chainid parameter

### DIFF
--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -116,6 +116,7 @@ func initFlags() {
 		validatorPubkeyFlag,
 		validatorPasswordFlag,
 		SyncModeFlag,
+		ChainIdFlag,
 	}
 	legacyRpcFlags = []cli.Flag{
 		utils.NoUSBFlag,


### PR DESCRIPTION
Until now the network / chainId is hard wired 501 for testnet and 500 for mainnet.
The trigger is the name of the genesisfile created (creategenesis parameter)

- If the filename is mainnet.g, 500 is used, otherwise 501.

This PR removes this hard coded value and introduces **creategenesis.chainid** parameter.
